### PR TITLE
댓글 관련 기능 구현

### DIFF
--- a/app/(afterLogin)/[userId]/post/[postId]/_component/CommentList.tsx
+++ b/app/(afterLogin)/[userId]/post/[postId]/_component/CommentList.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import {
+  DocumentData,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+} from 'firebase/firestore';
+import { useInView } from 'react-intersection-observer';
+import { useEffect } from 'react';
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import _ from 'lodash';
+
+import {
+  getCommentListFirst,
+  getCommentListNext,
+} from '@/app/(afterLogin)/[userId]/post/[postId]/_lib/getCommentList';
+import Loading from '@/app/loading';
+import PostCard from '@/app/(afterLogin)/_component/PostCard';
+import { IPostCommentProps, IPostData } from '@/app/types/post';
+
+const CommentList = ({ userId, postId }: IPostCommentProps) => {
+  const queryClient = useQueryClient();
+  const post = queryClient.getQueriesData({
+    queryKey: [userId, 'post', postId],
+  });
+
+  const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery<
+    QuerySnapshot<DocumentData, DocumentData>,
+    Object,
+    InfiniteData<QuerySnapshot<DocumentData, DocumentData>>,
+    [_1: string, _2: string, _3: string],
+    QueryDocumentSnapshot<DocumentData, DocumentData> | undefined
+  >({
+    queryKey: ['post', postId, 'comments'],
+    queryFn: ({ pageParam }) => {
+      return pageParam
+        ? getCommentListNext(postId, pageParam)
+        : getCommentListFirst(postId);
+    },
+    initialPageParam: undefined,
+    getNextPageParam: querySnapshots => {
+      if (querySnapshots.size < 20) return undefined;
+      else return querySnapshots.docs[querySnapshots.docs.length - 1];
+    },
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000,
+  });
+
+  const { ref, inView } = useInView({
+    threshold: 0.5,
+  });
+
+  const throttledFetchNextPage = _.throttle(fetchNextPage, 500);
+
+  useEffect(() => {
+    if (inView && !isFetching && hasNextPage) {
+      throttledFetchNextPage();
+    }
+  }, [hasNextPage, inView, isFetching, throttledFetchNextPage]);
+
+  const comments = data?.pages
+    .flatMap(page => page.docs)
+    .map(doc => ({ commentId: doc.id, comment: doc.data() }));
+
+  if (post) {
+    return (
+      <div className="flex h-full w-full flex-col">
+        {comments?.map(comment => (
+          <PostCard
+            key={comment.commentId}
+            postId={comment.commentId}
+            post={comment.comment as IPostData}
+            parentPostUserId={userId}
+          />
+        ))}
+        {hasNextPage && (
+          <div ref={ref} className="flex h-16 items-center justify-center">
+            <Loading />
+          </div>
+        )}
+      </div>
+    );
+  }
+};
+
+export default CommentList;

--- a/app/(afterLogin)/[userId]/post/[postId]/_component/WriteComment.tsx
+++ b/app/(afterLogin)/[userId]/post/[postId]/_component/WriteComment.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { usePostStore } from '@/app/store/usePost';
+
+interface IWriteCommentProps {
+  postId: string;
+}
+
+const WriteComment = ({ postId }: IWriteCommentProps) => {
+  const router = useRouter();
+  const { setMode, setParentPostId } = usePostStore();
+  const onWriteComment = () => {
+    setMode('comment');
+    setParentPostId(postId);
+    router.push('/post');
+  };
+
+  return (
+    <div
+      className="cursor-pointer border-y-2 border-black p-3 hover:bg-gray-50"
+      onClick={onWriteComment}
+    >
+      <p className="font-bold">답글 게시하기</p>
+    </div>
+  );
+};
+
+export default WriteComment;

--- a/app/(afterLogin)/[userId]/post/[postId]/_lib/getCommentList.ts
+++ b/app/(afterLogin)/[userId]/post/[postId]/_lib/getCommentList.ts
@@ -1,0 +1,45 @@
+import {
+  DocumentData,
+  QueryDocumentSnapshot,
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  where,
+} from 'firebase/firestore';
+
+import { db } from '@/app/firebase';
+
+export const getCommentListFirst = async (postId: string) => {
+  console.log('first comment 실행');
+  const first = query(
+    collection(db, 'Feed'),
+    where('parentFeedId', '==', postId),
+    orderBy('createdAt', 'desc'),
+    limit(20),
+  );
+
+  const postSnap = await getDocs(first);
+
+  return postSnap;
+};
+
+export const getCommentListNext = async (
+  postId: string,
+  pageParam: QueryDocumentSnapshot<DocumentData, DocumentData>,
+) => {
+  console.log('next comment 실행');
+  const next = query(
+    collection(db, 'Feed'),
+    where('parentFeedId', '==', postId),
+    orderBy('createdAt', 'desc'),
+    startAfter(pageParam),
+    limit(20),
+  );
+
+  const nextSnap = await getDocs(next);
+
+  return nextSnap;
+};

--- a/app/(afterLogin)/[userId]/post/[postId]/page.tsx
+++ b/app/(afterLogin)/[userId]/post/[postId]/page.tsx
@@ -6,6 +6,8 @@ import {
 
 import { getPostServer } from '@/app/(afterLogin)/[userId]/post/[postId]/_lib/getPostServer';
 import SinglePost from '@/app/(afterLogin)/[userId]/post/[postId]/_component/SinglePost';
+import CommentList from '@/app/(afterLogin)/[userId]/post/[postId]/_component/CommentList';
+import WriteComment from '@/app/(afterLogin)/[userId]/post/[postId]/_component/WriteComment';
 
 interface PostPageProps {
   params: { userId: string; postId: string };
@@ -22,13 +24,12 @@ const PostPage = async ({ params }: PostPageProps) => {
 
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="flex-grow p-4">
+      <div className="flex flex-grow flex-col p-4">
         <HydrationBoundary state={dehydratedState}>
           <SinglePost userId={userId} postId={postId} />
         </HydrationBoundary>
-        <div>
-          {userId}의 {postId}게시물 페이지입니다.
-        </div>
+        <WriteComment postId={postId} />
+        <CommentList userId={userId} postId={postId} />
       </div>
     </div>
   );

--- a/app/(afterLogin)/_component/BackButton.tsx
+++ b/app/(afterLogin)/_component/BackButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { IoArrowBack } from 'react-icons/io5';
+import { useRouter } from 'next/navigation';
+
+const BackButton = () => {
+  const router = useRouter();
+
+  const goBack = () => {
+    router.back();
+  };
+
+  return (
+    <IoArrowBack className="h-8 w-8 hover:cursor-pointer" onClick={goBack} />
+  );
+};
+
+export default BackButton;

--- a/app/(afterLogin)/_component/Header.tsx
+++ b/app/(afterLogin)/_component/Header.tsx
@@ -1,29 +1,19 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
-import { IoArrowBack } from 'react-icons/io5';
+import { usePathname } from 'next/navigation';
+import BackButton from '@/app/(afterLogin)/_component/BackButton';
 
 const Header = () => {
-  const router = useRouter();
   const pathname = usePathname();
 
-  const showBackButtonRoutes = ['/post', '/home/'];
-  const shouldShowBackButton = showBackButtonRoutes.some(path =>
+  const hiddenBackButtonRoutes = ['/search', '/home', '/messages'];
+  const hiddenBackButton = hiddenBackButtonRoutes.some(path =>
     pathname.startsWith(path),
   );
 
-  const goBack = () => {
-    router.back();
-  };
-
   return (
     <header className="fixed z-10 flex h-16 w-full max-w-screen-sm items-center bg-background px-4">
-      {shouldShowBackButton && (
-        <IoArrowBack
-          className="h-8 w-8 hover:cursor-pointer"
-          onClick={goBack}
-        />
-      )}
+      {!hiddenBackButton && <BackButton />}
     </header>
   );
 };

--- a/app/(afterLogin)/_component/NavigationItem.tsx
+++ b/app/(afterLogin)/_component/NavigationItem.tsx
@@ -3,11 +3,23 @@
 import Link from 'next/link';
 
 import { NavigationItemType } from '@/app/types/navigation';
+import { usePostStore } from '@/app/store/usePost';
 
 const NavigationItem = ({ icon: Icon, href, pathname }: NavigationItemType) => {
+  const { reset } = usePostStore();
+
+  const onReset = () => {
+    if (href === '/post') reset();
+  };
+
   return (
     <div className="relative h-full w-full">
-      <Link href={`${href}`} className="m-auto p-0" aria-label={href}>
+      <Link
+        href={`${href}`}
+        className="m-auto p-0"
+        aria-label={href}
+        onClick={onReset}
+      >
         <div className="m-1 flex h-5/6 w-[calc(100%-8px)] items-center justify-center hover:cursor-pointer hover:rounded-lg hover:bg-gray-100">
           <Icon size={30} color={pathname === href ? '#000000' : '#c5c0c0'} />
         </div>

--- a/app/(afterLogin)/_component/PostCard.tsx
+++ b/app/(afterLogin)/_component/PostCard.tsx
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { v4 as uuidv4 } from 'uuid';
 
-import { IPostListData } from '@/app/types/post';
+import { IPostCard } from '@/app/types/post';
 import { IUserData } from '@/app/types/user';
 import { getUser } from '@/app/(afterLogin)/users/[userId]/_lib/getUser';
 import { hashUid } from '@/app/_lib/hashUid';
@@ -17,7 +17,7 @@ import CommentCount from '@/app/(afterLogin)/home/_component/CommentCount';
 import PostSetting from '@/app/(afterLogin)/home/_component/PostSetting';
 import useOnAuth from '@/app/_lib/useOnAuth';
 
-const PostCard = ({ postId, post }: IPostListData) => {
+const PostCard = ({ postId, post, parentPostUserId }: IPostCard) => {
   const router = useRouter();
   const { user } = useOnAuth();
   const { data: userData } = useQuery<
@@ -78,8 +78,14 @@ const PostCard = ({ postId, post }: IPostListData) => {
             <CommentCount commentCount={post.commentCount} />
           </div>
         </div>
-        {user?.uid === post.userId && (
-          <PostSetting userId={user.uid} postId={postId} />
+        {(user?.uid === post.userId ||
+          user?.displayName === parentPostUserId) && (
+          <PostSetting
+            userId={user?.displayName as string}
+            postId={postId}
+            parentPostId={post.parentFeedId}
+            isCommentOwner={user?.uid === post.userId}
+          />
         )}
       </div>
       <hr className="absolute bottom-0 left-0 w-full" />

--- a/app/(afterLogin)/home/_component/PostList.tsx
+++ b/app/(afterLogin)/home/_component/PostList.tsx
@@ -38,6 +38,7 @@ const PostList = () => {
     staleTime: 60 * 1000,
     gcTime: 300 * 1000,
   });
+
   const { ref, inView } = useInView({
     threshold: 0.5,
   });
@@ -50,20 +51,20 @@ const PostList = () => {
     }
   }, [hasNextPage, inView, isFetching, throttledFetchNextPage]);
 
+  const posts = data?.pages
+    .flatMap(page => page.docs)
+    .map(doc => ({ postId: doc.id, post: doc.data() }));
+
   return (
     <div className="flex h-full w-full flex-col">
       <Suspense fallback={<Loading />}>
-        {data?.pages.flatMap(page =>
-          page.docs
-            .map(doc => ({ postId: doc.id, post: doc.data() }))
-            .map(post => (
-              <PostCard
-                key={post.postId}
-                postId={post.postId}
-                post={post.post as IPostData}
-              />
-            )),
-        )}
+        {posts?.map(post => (
+          <PostCard
+            key={post.postId}
+            postId={post.postId}
+            post={post.post as IPostData}
+          />
+        ))}
       </Suspense>
       {hasNextPage && (
         <div ref={ref} className="flex h-16 items-center justify-center">

--- a/app/(afterLogin)/home/_lib/deletePost.ts
+++ b/app/(afterLogin)/home/_lib/deletePost.ts
@@ -1,15 +1,23 @@
-import { deleteDoc, doc } from 'firebase/firestore';
+import { deleteDoc, doc, increment, updateDoc } from 'firebase/firestore';
 
-import { db } from '@/app/firebase';
+import { FEED_COLLECTION, db } from '@/app/firebase';
 
 interface IDeletePost {
   postId: string;
+  parentPostId?: string;
 }
 
-export const deletePost = async ({ postId }: IDeletePost) => {
+export const deletePost = async ({ postId, parentPostId }: IDeletePost) => {
   try {
     const postRef = doc(db, 'Feed', postId);
     await deleteDoc(postRef);
+
+    if (parentPostId) {
+      const parentPostRef = doc(FEED_COLLECTION, parentPostId);
+      await updateDoc(parentPostRef, {
+        commentCount: increment(-1),
+      });
+    }
 
     return true;
   } catch (error) {

--- a/app/(afterLogin)/home/_lib/getPostList.ts
+++ b/app/(afterLogin)/home/_lib/getPostList.ts
@@ -7,6 +7,7 @@ import {
   orderBy,
   query,
   startAfter,
+  where,
 } from 'firebase/firestore';
 
 import { db } from '@/app/firebase';
@@ -15,6 +16,7 @@ export const getPostListFirst = async () => {
   console.log('first 실행');
   const first = query(
     collection(db, 'Feed'),
+    where('parentFeedId', '==', ''),
     orderBy('createdAt', 'desc'),
     limit(10),
   );
@@ -30,6 +32,7 @@ export const getPostListNext = async (
   console.log('next 실행');
   const next = query(
     collection(db, 'Feed'),
+    where('parentFeedId', '==', ''),
     orderBy('createdAt', 'desc'),
     startAfter(pageParam),
     limit(10),

--- a/app/store/usePost.ts
+++ b/app/store/usePost.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { IPostData } from '../types/post';
+
+interface PostState {
+  mode: 'new' | 'comment';
+  data: IPostData | null;
+  parentPostId: string;
+  setMode: (mode: 'new' | 'comment') => void;
+  setData: (data: IPostData) => void;
+  setParentPostId: (postId: string) => void;
+  reset: () => void;
+}
+
+export const usePostStore = create<PostState>(set => ({
+  mode: 'new',
+  data: null,
+  parentPostId: '',
+  setMode: mode => {
+    set({
+      mode,
+    });
+  },
+  setData: data => {
+    set({ data });
+  },
+  setParentPostId: parentPostId => {
+    set({ parentPostId });
+  },
+  reset: () => {
+    set({
+      mode: 'new',
+      data: null,
+    });
+  },
+}));

--- a/app/types/post.ts
+++ b/app/types/post.ts
@@ -2,6 +2,7 @@ export interface IPostData {
   userId: string;
   commentCount: number;
   content: string;
+  parentFeedId: string;
   likeCount: number;
   photoUrl: string[];
   updatedAt: number;
@@ -13,9 +14,15 @@ export interface IPostListData {
   post: IPostData;
 }
 
+export interface IPostCard extends IPostListData {
+  parentPostUserId?: string;
+}
+
 export interface IPostSetting {
   userId: string;
   postId: string;
+  parentPostId?: string;
+  isCommentOwner?: boolean;
 }
 
 export interface IPostInputs {
@@ -27,4 +34,9 @@ export interface IUpdatePost {
   photoUrl: string[];
   content: string;
   updatedAt: number;
+}
+
+export interface IPostCommentProps {
+  userId: string;
+  postId: string;
 }


### PR DESCRIPTION
#19 #20 #21  
Comment 컬렉션을 따로 만들지 않고 기존에 게시글로 사용하던 Feed 컬렉션에 parenFeedId를 사용하여 상속받을 수 있도록 설계함. 
이를 활용하여 기존에 만들었던 Post관련 컴포넌트들을 재사용할 수 있었음

Feat
게시물 댓글 목록 가져오기 / 무한스크롤 구현
게시물 댓글 작성 기능 구현
게시물 댓글 수정 기능 구현
게시물 댓글 삭제 기능 구현

(추가적인 요소)
Feat
뒤로가기 버튼 컴포넌트 분리
헤더의 뒤로가기 버튼 표시 조건 변경
Post관련 공통 타입 추가
게시글, 댓글 구별을 위한 전역 변수 추가

Refactor
Navigation Item 중 post에 접근시 게시글을 작성할 수 있도록 설정
PostList 가져오는 로직 변경

기능 구현만 한거라 추후 오류 발생 시 수정 필요