### PR TITLE
팔로우 언팔로우 기능 구현

### DIFF
--- a/app/(afterLogin)/[userId]/post/[postId]/_lib/getCommentList.ts
+++ b/app/(afterLogin)/[userId]/post/[postId]/_lib/getCommentList.ts
@@ -1,7 +1,6 @@
 import {
   DocumentData,
   QueryDocumentSnapshot,
-  collection,
   getDocs,
   limit,
   orderBy,
@@ -10,12 +9,12 @@ import {
   where,
 } from 'firebase/firestore';
 
-import { db } from '@/app/firebase';
+import { FEED_COLLECTION } from '@/app/firebase';
 
 export const getCommentListFirst = async (postId: string) => {
   console.log('first comment 실행');
   const first = query(
-    collection(db, 'Feed'),
+    FEED_COLLECTION,
     where('parentFeedId', '==', postId),
     orderBy('createdAt', 'desc'),
     limit(20),
@@ -32,7 +31,7 @@ export const getCommentListNext = async (
 ) => {
   console.log('next comment 실행');
   const next = query(
-    collection(db, 'Feed'),
+    FEED_COLLECTION,
     where('parentFeedId', '==', postId),
     orderBy('createdAt', 'desc'),
     startAfter(pageParam),

--- a/app/(afterLogin)/_component/PostCard.tsx
+++ b/app/(afterLogin)/_component/PostCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEvent } from 'react';
+import { MouseEvent, MouseEventHandler } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
@@ -16,17 +16,19 @@ import { formatDateTime } from '@/app/_lib/formatDateTime';
 import CommentCount from '@/app/(afterLogin)/home/_component/CommentCount';
 import PostSetting from '@/app/(afterLogin)/home/_component/PostSetting';
 import useOnAuth from '@/app/_lib/useOnAuth';
+import Link from 'next/link';
 
 const PostCard = ({ postId, post, parentPostUserId }: IPostCard) => {
   const router = useRouter();
   const { user } = useOnAuth();
+  const hashedUid = hashUid({ uid: post.userId });
   const { data: userData } = useQuery<
     IUserData | null,
     Object,
     IUserData,
     [_1: string, _2: string]
   >({
-    queryKey: ['users', hashUid({ uid: post.userId })],
+    queryKey: ['users', hashedUid],
     queryFn: getUser,
     staleTime: 60 * 1000,
     gcTime: 300 * 1000,
@@ -34,7 +36,11 @@ const PostCard = ({ postId, post, parentPostUserId }: IPostCard) => {
 
   const goPost = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
-    router.push(`/${user?.displayName}/post/${postId}`);
+    router.push(`/${hashedUid}/post/${postId}`);
+  };
+
+  const stopPropagation: MouseEventHandler<HTMLAnchorElement> = e => {
+    e.stopPropagation();
   };
 
   return (
@@ -54,7 +60,13 @@ const PostCard = ({ postId, post, parentPostUserId }: IPostCard) => {
         </Avatar>
         <div className="flex w-full flex-col">
           <div className="flex flex-row gap-2">
-            <span className="font-bold">{userData?.nickname}</span>
+            <Link
+              href={`/users/${hashedUid}`}
+              className="hover:underline"
+              onClick={stopPropagation}
+            >
+              <span className="font-bold">{userData?.nickname}</span>
+            </Link>
             <p className="font-light text-gray-400">
               {formatDateTime({ createdAt: post.createdAt })}
             </p>

--- a/app/(afterLogin)/home/_component/FollowPostList.tsx
+++ b/app/(afterLogin)/home/_component/FollowPostList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import useOnAuth from '@/app/_lib/useOnAuth';
+import { IPostListData } from '@/app/types/post';
+import { getFollowingPostList } from '@/app/(afterLogin)/home/_lib/getFollowingPostList';
+import Loading from '@/app/(afterLogin)/home/loading';
+import PostCard from '../../_component/PostCard';
+
+const FollowPostList = () => {
+  const { user } = useOnAuth();
+
+  const { data: followPostData, isLoading } = useQuery<
+    IPostListData[] | null,
+    Object,
+    IPostListData[],
+    [_1: string, _2: string, _3: string]
+  >({
+    queryKey: ['post', user?.displayName as string, 'following'],
+    queryFn: getFollowingPostList,
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000,
+    enabled: !!user?.displayName,
+  });
+
+  if (!isLoading && !followPostData) {
+    return <div>팔로잉 중인 유저의 포스트가 없습니다...</div>;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <Suspense fallback={<Loading />}>
+        {followPostData?.map(post => (
+          <PostCard key={post.postId} postId={post.postId} post={post.post} />
+        ))}
+      </Suspense>
+    </div>
+  );
+};
+
+export default FollowPostList;

--- a/app/(afterLogin)/home/_component/Tab.tsx
+++ b/app/(afterLogin)/home/_component/Tab.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useContext } from 'react';
+import { TabContext } from '@/app/(afterLogin)/home/_component/TabProvider';
+
+const Tab = () => {
+  const { tab, setTab } = useContext(TabContext);
+
+  const onClickMain = () => {
+    setTab('main');
+  };
+
+  const onClickFollow = () => {
+    setTab('fol');
+  };
+
+  return (
+    <div className="grid w-full cursor-pointer grid-cols-2">
+      <div
+        className={`flex flex-col items-center border-b py-4 text-gray-400 ${tab === 'main' && 'border-black font-bold text-black'}`}
+        onClick={onClickMain}
+      >
+        메인
+      </div>
+      <div
+        className={`flex flex-col items-center border-b py-4 text-gray-400 ${tab === 'fol' && 'border-black font-bold text-black'}`}
+        onClick={onClickFollow}
+      >
+        팔로잉
+      </div>
+    </div>
+  );
+};
+
+export default Tab;

--- a/app/(afterLogin)/home/_component/TabDecider.tsx
+++ b/app/(afterLogin)/home/_component/TabDecider.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useContext } from 'react';
+import { TabContext } from '@/app/(afterLogin)/home/_component/TabProvider';
+import PostList from '@/app/(afterLogin)/home/_component/PostList';
+import FollowPostList from '@/app/(afterLogin)/home/_component/FollowPostList';
+
+const TabDecider = () => {
+  const { tab } = useContext(TabContext);
+
+  if (tab === 'main') {
+    return <PostList />;
+  }
+
+  return <FollowPostList />;
+};
+
+export default TabDecider;

--- a/app/(afterLogin)/home/_component/TabProvider.tsx
+++ b/app/(afterLogin)/home/_component/TabProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { ReactNode, createContext, useState } from 'react';
+
+export const TabContext = createContext({
+  tab: 'main',
+  setTab: (value: 'main' | 'fol') => {},
+});
+
+type Props = { children: ReactNode };
+
+const TabProvider = ({ children }: Props) => {
+  const [tab, setTab] = useState('main');
+
+  return (
+    <TabContext.Provider value={{ tab, setTab }}>
+      {children}
+    </TabContext.Provider>
+  );
+};
+
+export default TabProvider;

--- a/app/(afterLogin)/home/_lib/getFollowingPostList.ts
+++ b/app/(afterLogin)/home/_lib/getFollowingPostList.ts
@@ -1,0 +1,41 @@
+import { QueryFunction } from '@tanstack/react-query';
+import { getDocs, query, where, orderBy } from 'firebase/firestore';
+import { FEED_COLLECTION } from '@/app/firebase';
+
+import { IPostData, IPostListData } from '@/app/types/post';
+import { getFollowData } from '@/app/(afterLogin)/users/[userId]/_lib/getFollowData';
+
+export const getFollowingPostList: QueryFunction<
+  IPostListData[] | null,
+  [_1: string, _2: string, _3: string]
+> = async ({ queryKey, signal, meta }) => {
+  // eslint-disable-next-line no-unused-vars
+  const [_1, userId, _3] = queryKey;
+
+  try {
+    const followData = await getFollowData({
+      queryKey: ['follow', userId],
+      signal,
+      meta,
+    });
+    const followingUserIds = followData?.followingUserId || [];
+
+    const feedQuery = query(
+      FEED_COLLECTION,
+      where('hashedUserId', 'in', followingUserIds),
+      where('parentFeedId', '==', ''),
+      orderBy('createdAt', 'desc'),
+    );
+
+    const feedQuerySnapshot = await getDocs(feedQuery);
+    const feeds = feedQuerySnapshot.docs.map(doc => ({
+      postId: doc.id,
+      post: doc.data() as IPostData,
+    }));
+
+    return feeds || [];
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/app/(afterLogin)/home/_lib/getPostList.ts
+++ b/app/(afterLogin)/home/_lib/getPostList.ts
@@ -1,7 +1,6 @@
 import {
   DocumentData,
   QueryDocumentSnapshot,
-  collection,
   getDocs,
   limit,
   orderBy,
@@ -10,12 +9,12 @@ import {
   where,
 } from 'firebase/firestore';
 
-import { db } from '@/app/firebase';
+import { FEED_COLLECTION } from '@/app/firebase';
 
 export const getPostListFirst = async () => {
   console.log('first 실행');
   const first = query(
-    collection(db, 'Feed'),
+    FEED_COLLECTION,
     where('parentFeedId', '==', ''),
     orderBy('createdAt', 'desc'),
     limit(10),
@@ -31,7 +30,7 @@ export const getPostListNext = async (
 ) => {
   console.log('next 실행');
   const next = query(
-    collection(db, 'Feed'),
+    FEED_COLLECTION,
     where('parentFeedId', '==', ''),
     orderBy('createdAt', 'desc'),
     startAfter(pageParam),

--- a/app/(afterLogin)/home/_lib/writePost.ts
+++ b/app/(afterLogin)/home/_lib/writePost.ts
@@ -25,6 +25,7 @@ export const writePost = async ({ user, data, parentPostId }: IWritePost) => {
         updatedAt: Date.now(),
         photoUrl: [],
         parentFeedId: parentPostId || '',
+        hashedUserId: user.displayName,
       };
       const newDocRef = await addDoc(postRef, feedData);
 

--- a/app/(afterLogin)/home/page.tsx
+++ b/app/(afterLogin)/home/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
 
-import PostList from '@/app/(afterLogin)/home/_component/PostList';
+import TabProvider from '@/app/(afterLogin)/home/_component/TabProvider';
+import Tab from '@/app/(afterLogin)/home/_component/Tab';
+import TabDecider from '@/app/(afterLogin)/home/_component/TabDecider';
 
 export const metadata: Metadata = {
   title: '홈 / Stockaca',
@@ -9,9 +11,10 @@ export const metadata: Metadata = {
 
 const HomePage = async () => {
   return (
-    <>
-      <PostList />
-    </>
+    <TabProvider>
+      <Tab />
+      <TabDecider />
+    </TabProvider>
   );
 };
 

--- a/app/(afterLogin)/layout.tsx
+++ b/app/(afterLogin)/layout.tsx
@@ -4,6 +4,7 @@ import RedirectToLogin from '@/app/(afterLogin)/_component/RedirectToLogin';
 import NavigationBar from '@/app/(afterLogin)/_component/NavigationBar';
 import RQProvider from '@/app/(afterLogin)/_component/RQProvider';
 import Header from '@/app/(afterLogin)/_component/Header';
+import FollowModal from '@/app/(afterLogin)/users/[userId]/_component/FollowModal';
 
 type Props = { children: ReactNode };
 
@@ -16,6 +17,7 @@ const AfterLoginLayout = ({ children }: Props) => {
         {children}
       </div>
       <NavigationBar />
+      <FollowModal />
     </RQProvider>
   );
 };

--- a/app/(afterLogin)/users/[userId]/_component/FollowButton.tsx
+++ b/app/(afterLogin)/users/[userId]/_component/FollowButton.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import useOnAuth from '@/app/_lib/useOnAuth';
+import { IFollowData } from '@/app/types/follow';
+import { Button } from '@/components/ui/button';
+import { follow } from '@/app/(afterLogin)/users/[userId]/_lib/follow';
+import { unFollow } from '@/app/(afterLogin)/users/[userId]/_lib/unFollow';
+
+interface IFollowProps {
+  userId: string;
+  followData: IFollowData;
+}
+
+const FollowButton = ({ userId, followData }: IFollowProps) => {
+  const queryClient = useQueryClient();
+  const { user } = useOnAuth();
+  const [isFollow, setIsFollow] = useState(false);
+
+  useEffect(() => {
+    setIsFollow(
+      followData?.followerUserId.includes(user?.displayName as string),
+    );
+  }, [followData?.followerUserId, user?.displayName]);
+
+  const onFollow = useMutation({
+    mutationFn: () =>
+      follow({
+        currentUserId: user?.displayName as string,
+        targetUserId: userId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['follow', userId] });
+      queryClient.invalidateQueries({
+        queryKey: ['follow', user?.displayName],
+      });
+      setIsFollow(true);
+      toast.success('팔로우 완료');
+    },
+    onError: error => {
+      console.error('Error follow user:', error);
+      toast.error('팔로우 실패');
+    },
+  });
+
+  const onUnFollow = useMutation({
+    mutationFn: () =>
+      unFollow({
+        currentUserId: user?.displayName as string,
+        targetUserId: userId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['follow', userId] });
+      queryClient.invalidateQueries({
+        queryKey: ['follow', user?.displayName],
+      });
+      setIsFollow(false);
+      toast.success('언팔로우 완료');
+    },
+    onError: error => {
+      console.error('Error follow user:', error);
+      toast.error('언팔로우 실패');
+    },
+  });
+
+  if (user?.displayName === userId) {
+    return null;
+  }
+
+  return (
+    <>
+      {isFollow ? (
+        <Button variant="outline" onClick={() => onUnFollow.mutate()}>
+          팔로잉
+        </Button>
+      ) : (
+        <Button onClick={() => onFollow.mutate()}>팔로우</Button>
+      )}
+    </>
+  );
+};
+
+export default FollowButton;

--- a/app/(afterLogin)/users/[userId]/_component/FollowCard.tsx
+++ b/app/(afterLogin)/users/[userId]/_component/FollowCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { IUserData } from '@/app/types/user';
+import { getUser } from '@/app/(afterLogin)/users/[userId]/_lib/getUser';
+import { Avatar } from '@/components/ui/avatar';
+import Image from 'next/image';
+import Link from 'next/link';
+import useFollowModalStore from '@/app/store/useFollowModal';
+
+interface IFollowCardProps {
+  userId: string;
+}
+
+const FollowCard = ({ userId }: IFollowCardProps) => {
+  const { onChange } = useFollowModalStore();
+  const { data: userData } = useQuery<
+    IUserData | null,
+    Object,
+    IUserData,
+    [_1: string, _2: string]
+  >({
+    queryKey: ['users', userId],
+    queryFn: getUser,
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000,
+  });
+
+  return (
+    <Link href={`/users/${userId}`} onClick={onChange}>
+      <div className="flex gap-3 border-b py-4">
+        <Avatar className="h-12 w-12">
+          {userData?.profileImage && (
+            <Image
+              src={userData?.profileImage}
+              alt="프로필 사진"
+              width={300}
+              height={300}
+              placeholder="blur"
+              blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+            />
+          )}
+        </Avatar>
+        <div className="flex flex-col">
+          <p className="font-bold hover:underline">{userData?.nickname}</p>
+          <p className="font-thin text-gray-400">{userData?.name}</p>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default FollowCard;

--- a/app/(afterLogin)/users/[userId]/_component/FollowModal.tsx
+++ b/app/(afterLogin)/users/[userId]/_component/FollowModal.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import useFollowModalStore from '@/app/store/useFollowModal';
+import { getFollowData } from '@/app/(afterLogin)/users/[userId]/_lib/getFollowData';
+import { IFollowData } from '@/app/types/follow';
+import FollowCard from './FollowCard';
+
+type selectedType = 'follower' | 'following';
+
+const FollowModal = () => {
+  const { isOpen, onChange, userId } = useFollowModalStore();
+  const [selectedTab, setSelectedTab] = useState<selectedType>('follower');
+
+  const { data: followData } = useQuery<
+    IFollowData | null,
+    Object,
+    IFollowData,
+    [_1: string, _2: string]
+  >({
+    queryKey: ['follow', userId],
+    queryFn: getFollowData,
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000,
+    enabled: !!userId,
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onChange}>
+      <DialogContent className="max-h-[90%] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>팔로우 / 팔로잉 목록</DialogTitle>
+        </DialogHeader>
+        <div className="my-2 flex flex-col">
+          <div className="grid cursor-pointer grid-cols-2">
+            <div
+              className={`flex flex-col items-center border-b pb-2 ${selectedTab === 'follower' && 'border-black font-bold'}`}
+              onClick={() => setSelectedTab('follower')}
+            >
+              <p>팔로워</p>
+            </div>
+            <div
+              className={`flex flex-col items-center border-b pb-2 ${selectedTab === 'following' && 'border-black font-bold'}`}
+              onClick={() => setSelectedTab('following')}
+            >
+              <p>팔로잉</p>
+            </div>
+          </div>
+          {selectedTab === 'follower' &&
+            followData?.followerUserId.map(user => (
+              <FollowCard key={user} userId={user} />
+            ))}
+          {selectedTab === 'following' &&
+            followData?.followingUserId.map(user => (
+              <FollowCard key={user} userId={user} />
+            ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FollowModal;

--- a/app/(afterLogin)/users/[userId]/_component/LogoutButton.tsx
+++ b/app/(afterLogin)/users/[userId]/_component/LogoutButton.tsx
@@ -4,19 +4,19 @@ import { Button } from '@/components/ui/button';
 import { logout } from '@/app/(afterLogin)/users/[userId]/_lib/logout';
 import useOnAuth from '@/app/_lib/useOnAuth';
 
-interface LogoutButtonProps {
+interface ILogoutProps {
   userId: string;
 }
 
-const LogoutButton = ({ userId }: LogoutButtonProps) => {
+const LogoutButton = ({ userId }: ILogoutProps) => {
   const { user } = useOnAuth();
 
+  if (user?.displayName !== userId) {
+    return null;
+  }
+
   return (
-    <Button
-      onClick={logout}
-      className="mx-2"
-      hidden={user?.displayName !== userId}
-    >
+    <Button onClick={logout} variant="outline">
       로그아웃
     </Button>
   );

--- a/app/(afterLogin)/users/[userId]/_lib/follow.ts
+++ b/app/(afterLogin)/users/[userId]/_lib/follow.ts
@@ -1,0 +1,20 @@
+import { FOLLOW_COLLECTION } from '@/app/firebase';
+import { IFollowId } from '@/app/types/follow';
+import { addDoc } from 'firebase/firestore';
+
+export const follow = async ({ currentUserId, targetUserId }: IFollowId) => {
+  try {
+    const followRef = FOLLOW_COLLECTION;
+    const followData = {
+      followerUserId: currentUserId,
+      followingUserId: targetUserId,
+    };
+
+    await addDoc(followRef, followData);
+
+    return true;
+  } catch (error) {
+    console.log('Error following user:', error);
+    throw new Error('Failed to follow user');
+  }
+};

--- a/app/(afterLogin)/users/[userId]/_lib/getFollowData.ts
+++ b/app/(afterLogin)/users/[userId]/_lib/getFollowData.ts
@@ -1,0 +1,44 @@
+import { getDocs, query, where } from 'firebase/firestore';
+import { QueryFunction } from '@tanstack/react-query';
+
+import { FOLLOW_COLLECTION } from '@/app/firebase';
+import { IFollowData } from '@/app/types/follow';
+
+export const getFollowData: QueryFunction<
+  IFollowData | null,
+  [_1: string, _2: string]
+> = async ({ queryKey }) => {
+  // eslint-disable-next-line no-unused-vars
+  const [_1, userId] = queryKey;
+  try {
+    const followingQuery = query(
+      FOLLOW_COLLECTION,
+      where('followingUserId', '==', userId),
+    );
+
+    const followerQuery = query(
+      FOLLOW_COLLECTION,
+      where('followerUserId', '==', userId),
+    );
+
+    const followingQuerySnapshot = await getDocs(followingQuery);
+    const followingUsers = followingQuerySnapshot.docs.map(
+      doc => doc.data().followerUserId,
+    );
+
+    const followerQuerySnapshot = await getDocs(followerQuery);
+    const followerUsers = followerQuerySnapshot.docs.map(
+      doc => doc.data().followingUserId,
+    );
+
+    const followData = {
+      followerUserId: followingUsers || [],
+      followingUserId: followerUsers || [],
+    };
+
+    return followData;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/app/(afterLogin)/users/[userId]/_lib/unFollow.ts
+++ b/app/(afterLogin)/users/[userId]/_lib/unFollow.ts
@@ -1,0 +1,28 @@
+import { FOLLOW_COLLECTION } from '@/app/firebase';
+import { IFollowId } from '@/app/types/follow';
+import { deleteDoc, getDocs, query, where } from 'firebase/firestore';
+
+export const unFollow = async ({ currentUserId, targetUserId }: IFollowId) => {
+  try {
+    const followQuery = query(
+      FOLLOW_COLLECTION,
+      where('followerUserId', '==', currentUserId),
+      where('followingUserId', '==', targetUserId),
+    );
+
+    const followQuerySnapshot = await getDocs(followQuery);
+
+    if (followQuerySnapshot.empty) {
+      console.log('No follow relationship found to unfollow');
+      return false;
+    }
+
+    const followDoc = followQuerySnapshot.docs[0];
+    await deleteDoc(followDoc.ref);
+
+    return true;
+  } catch (error) {
+    console.log('Error following user:', error);
+    throw new Error('Failed to follow user');
+  }
+};

--- a/app/(afterLogin)/users/[userId]/page.tsx
+++ b/app/(afterLogin)/users/[userId]/page.tsx
@@ -4,7 +4,6 @@ import {
   dehydrate,
 } from '@tanstack/react-query';
 
-import LogoutButton from '@/app/(afterLogin)/users/[userId]/_component/LogoutButton';
 import UserProfile from '@/app/(afterLogin)/users/[userId]/_component/UserProfile';
 import { getUserServer } from '@/app/(afterLogin)/users/[userId]/_lib/getUserServer';
 
@@ -13,7 +12,7 @@ interface UserPageProps {
 }
 
 const UserPage = async ({ params }: UserPageProps) => {
-  const userId = decodeURIComponent(params.userId);
+  const { userId } = params;
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({
@@ -29,8 +28,8 @@ const UserPage = async ({ params }: UserPageProps) => {
         <HydrationBoundary state={dehydratedState}>
           <UserProfile userId={userId} />
         </HydrationBoundary>
-        <LogoutButton userId={userId} />
       </div>
+      <hr />
     </div>
   );
 };

--- a/app/firebase.js
+++ b/app/firebase.js
@@ -23,4 +23,5 @@ export const db = getFirestore(app);
 export const USER_COLLECTION = collection(db, 'User');
 export const FEED_COLLECTION = collection(db, 'Feed');
 export const LIKE_COLLECTION = collection(db, 'Like');
+export const FOLLOW_COLLECTION = collection(db, 'Follow');
 export const storage = getStorage(app);

--- a/app/store/useFollowModal.ts
+++ b/app/store/useFollowModal.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+interface FollowModalStore {
+  isOpen: boolean;
+  userId: string;
+  onSetUserId: (id: string) => void;
+  onReSetUserId: () => void;
+  onChange: () => void;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+const useFollowModalStore = create<FollowModalStore>(set => ({
+  isOpen: false,
+  userId: '',
+  onSetUserId: (id: string) => set({ userId: id }),
+  onReSetUserId: () => set({ userId: '' }),
+  onChange: () =>
+    set(state => {
+      if (state.isOpen) {
+        state.onReSetUserId();
+      }
+      const changedIsOpen = !state.isOpen;
+
+      return { isOpen: changedIsOpen };
+    }),
+  onOpen: () => set({ isOpen: true }),
+  onClose: () => set({ isOpen: false }),
+}));
+
+export default useFollowModalStore;

--- a/app/types/follow.ts
+++ b/app/types/follow.ts
@@ -1,0 +1,9 @@
+export interface IFollowData {
+  followerUserId: string[];
+  followingUserId: string[];
+}
+
+export interface IFollowId {
+  currentUserId: string;
+  targetUserId: string;
+}

--- a/app/types/post.ts
+++ b/app/types/post.ts
@@ -7,6 +7,7 @@ export interface IPostData {
   photoUrl: string[];
   updatedAt: number;
   createdAt: number;
+  hashedUserId: number;
 }
 
 export interface IPostListData {


### PR DESCRIPTION
#32
Feat
사용자의 프로필 페이지 또는 My page에 팔로잉 및 팔로워 수 표시
팔로우 및 팔로잉 중인 사용자의 리스트를 제공
사용자는 다른 사용자를 팔로우하거나 언팔로우 가능
팔로우한 사용자의 게시글만 표시되는 페이지 제공
follow, post 공통 타입 추가

Refactor
닉네임 클릭 시 유저 상세페이지로 라우팅
UserProfile 컴포넌트 안으로 로그아웃 버튼 삽입
유저 상세페이지에서 팔로우 유저 데이터 조회 
FEED 콜렉션 변수로 변경
게시물 작성 시 hashedUserId도 데이터에 post 되도록 변경